### PR TITLE
Add csv as an additional output to the check_privesc function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -501,4 +501,5 @@ paket-files/
 
 PrivEscScanner/all_org_folder_proj_sa_permissions.json
 PrivEscScanner/privesc_methods.txt
+PrivEscScanner/privesc_methods.csv
 PrivEscScanner/setIamPolicy_methods.txt


### PR DESCRIPTION
This simply adds a third output mechanism (csv) to the check_privesc function. (Console output and text file existed, csv is new). 

I opted to add this without with introducing an argument since there are no arguments currently and it's just adding functionality and not changing anything. That said, I can hide this behind an argument if you'd like. 